### PR TITLE
Error if gnuplot is not installed

### DIFF
--- a/irteus/gnuplotlib.l
+++ b/irteus/gnuplotlib.l
@@ -30,6 +30,8 @@
 
 (defmethod gnuplot
   (:init (host &key (clear t) ((:debug _debug)))
+     (when (eq (unix:system "which gnuplot") 256)
+       (error "gnuplot is not installed. $ sudo apt-get install gnuplot"))
 	 (setq strm 
 	       (cond
 		((string= (unix:gethostname) host)


### PR DESCRIPTION
gnuplot class output error if gnuplot is not installed.

I tested the code below:
https://github.com/euslisp/jskeus/pull/595

```lisp
4.irteusgl$ (graph-view (list r-pos r-vel r-acc) (cadr (memq :time r)) :keylist (list "position" "velocity" "acceleration"))
Call Stack (max depth: 20):
  0: at (error "gnuplot is not installed. $ sudo apt-get install gnuplot")
  1: at (progn (error "gnuplot is not installed. $ sudo apt-get install gnuplot"))
  2: at (if (eq (unix:system "which gnuplot") 256) (progn (error "gnuplot is not installed. $ sudo apt-get install gnuplot")))
  3: at (when (eq (unix:system "which gnuplot") 256) (error "gnuplot is not installed. $ sudo apt-get install gnuplot"))
  4: at (send #:inst364 :init host)
  5: at (let ((#:inst364 (instantiate gnuplot))) (send #:inst364 :init host) #:inst364)
  6: at (instance gnuplot :init host)
  7: at (gnuplot)
  8: at (setq *gp* (gnuplot))
  9: at (if (boundp '*gp*) *gp* (setq *gp* (gnuplot)))
  10: at (graph-view (list r-pos r-vel r-acc) (cadr (memq :time r)) :keylist (list "position" "velocity" "acceleration"))
  11: at #<compiled-code #X55adfca79e18>
/opt/ros/melodic/share/euslisp/jskeus/eus/Linux64/bin/irteusgl 0 error: gnuplot is not installed. $ sudo apt-get install gnuplot in (error "gnuplot is not installed. $ sudo apt-get install gnuplot")
```